### PR TITLE
The bug that lead to creation of large areas in the sea with zero val…

### DIFF
--- a/topotools.py
+++ b/topotools.py
@@ -89,9 +89,15 @@ class RasterTools(QgsRasterLayer):
 		# feedback.progressChanged.connect(self.send_progress_feedback)
 		#If the above two lines are uncommented, the feedback=feedback should be added to the processing algorithm below.
 
-		processing.run("gdal:fillnodata",
-		               {'INPUT': input_layer, 'BAND': 1, 'DISTANCE': 100, 'ITERATIONS': 0, 'NO_MASK': False,
-		                'MASK_LAYER': mask_layer, 'OUTPUT': out_file_path})
+		fill_params = {'INPUT': input_layer,
+					   'BAND': 1,
+					   'DISTANCE': 100,
+					   'ITERATIONS': 0,
+					   'NO_MASK': False,
+					   'MASK_LAYER': mask_layer,
+					   'OUTPUT': out_file_path}
+
+		processing.run("gdal:fillnodata", fill_params)
 
 
 		in_band.FlushCache()


### PR DESCRIPTION
…ues after interpolation is fixed. The interpolation tool sets shoreline to zero and removes any value that is above sea level in the sea and below sea level in the land, interpolating leftover empty cells from adjacent cells. If large areas are empty they will be interpolated from shorelines only, which are zero leaving vast areas with zero values between shorelines. Now, these zero-value areas are filled with their rescaled old values. The values are rescaled below sea level, if they are in the sea, and above sea level in the land.